### PR TITLE
Add pkgdown infrastructure to deploy to GitHub pages

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,6 @@
 ^LICENSE\.md$
 ^episodes\.Rproj$
 ^\.github$
+^_pkgdown\.yml$
+^docs$
+^pkgdown$

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,46 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+name: pkgdown
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
+
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .Rproj.user
+docs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,3 +19,4 @@ Suggests:
     ivs,
     tibble,
     tinytest
+URL: https://TimTaylor.github.io/episodes/

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,4 @@
+url: https://TimTaylor.github.io/episodes/
+template:
+  bootstrap: 5
+


### PR DESCRIPTION
You would need to enable this in the repo settings but basically, it will automatically create a nice pkgdown website from your readme and function documentation.

It's always my go-to thing when I look at a new package and it's nicer to share that link rather than the GitHub one, particularly if people will use your package, rather than want to see or contribute to the code.